### PR TITLE
Add Korean Pokémon Gen 4 support

### DIFF
--- a/formats/PM4F/pocketmonstersgen4font.h
+++ b/formats/PM4F/pocketmonstersgen4font.h
@@ -40,5 +40,7 @@ namespace NintyFont::NTR::PM4
         static bool identifyFile(uint8_t *bytes);
         static std::string returnFileTypeString(void);
         static std::string returnFileExtensionString(void);
+        //Fields
+        bool isKorean;
     };
 }


### PR DESCRIPTION
Korean games include an additional header in the character width block to apply run-length encoding to the character widths. This adds support for viewing as well as editing the Korean fonts.